### PR TITLE
add joltphysicssharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,12 @@ Add your library at <https://github.com/Apostolique/MonoGameLibraries/>.
   * `A 2D collision detection system.`
   * <https://github.com/nkast/Aether.Physics2D>
 
+* **JoltPhysicsSharp**
+  * `Cross platform modern .net9.0 and .net8.0 bindings for JoltPhysics using joltc.`
+  * <https://github.com/amerkoleci/JoltPhysicsSharp>
+
 * **Jitterphysics2**
-  * `A 3D physics engine with a beginner-friendly api`
+  * `A 3D physics engine with a beginner-friendly api.`
   * <https://github.com/notgiven688/jitterphysics2>
 
 ```


### PR DESCRIPTION
Joltphysicssharp is a well maintained C# bindings library for the JoltPhysics 3D physics library. It is used by Horizon Forbidden West which is a triple-A title. Pretty cool!